### PR TITLE
Fix flag dismissal bug

### DIFF
--- a/flagfilter.js
+++ b/flagfilter.js
@@ -1594,7 +1594,7 @@ function initKeyboard()
 
             if (action.clickOrLink) {
                 var jElem = $(action.clickOrLink),
-                    evData = jElem.data("events"),
+                    evData = $._data($(jElem).get(0), "events"),
                     doClick = false;
                 if (evData && evData.click && evData.click.length) // click handler bound?
                     doClick = true;

--- a/flagfilter.js
+++ b/flagfilter.js
@@ -1594,12 +1594,12 @@ function initKeyboard()
 
             if (action.clickOrLink) {
                 var jElem = $(action.clickOrLink),
-                    evData = $._data($(jElem).get(0), "events"),
+                    evData = $._data(jElem.get(0), "events"),
                     doClick = false;
                 if (evData && evData.click && evData.click.length) // click handler bound?
                     doClick = true;
                 else {
-                    evData = $(document).data("events"); // live handler bound? (note that the generic delegate case is *not* checked)
+                    evData = $._data(document, "events"); // live handler bound? (note that the generic delegate case is *not* checked)
                     if (evData && evData.click) {
                         for (var i = 0; i < evData.click.length; i++) {
                             var sel = evData.click[i].selector;


### PR DESCRIPTION
data("events") was removed from the user namespace in some version of jQuery. See http://stackoverflow.com/a/2518441/1849664.

This feels hopelessly hacky, but it does seem to _work_. 
