### PR TITLE
fix the close button

### DIFF
--- a/MonicasFlagToC.user.js
+++ b/MonicasFlagToC.user.js
@@ -186,16 +186,17 @@ function initStyles()
    }
 
    #postflag-bar .nav-button.close a {
+      background-color: #6a737c;
+      border: 1px solid #9fa6ad;
+      border-radius: 10px;
       color: white;
       display: block;
       padding: 2px 5px;
-      border: 1px solid #9fa6ad;
-      background-color: #6a737c;
-      border-radius: 10px;
    }
 
    #postflag-bar .nav-button.close a:hover {
-      color: white;
+      background-color: white;
+      color: #9fa6ad;
    }
    `;
 

--- a/MonicasFlagToC.user.js
+++ b/MonicasFlagToC.user.js
@@ -170,6 +170,33 @@ function initStyles()
    {
       white-space: nowrap;
    }
+
+   /* fix close button in the flag bar to make the whole thing clickable */
+
+   #postflag-bar .nav-button.close {
+      color: unset;
+      padding: unset;
+      border: unset;
+      border-radius: unset;
+      background-color: unset;
+   }
+
+   #postflag-bar .nav-button.close:hover {
+      color: unset;
+   }
+
+   #postflag-bar .nav-button.close a {
+      color: white;
+      display: block;
+      padding: 2px 5px;
+      border: 1px solid #9fa6ad;
+      background-color: #6a737c;
+      border-radius: 10px;
+   }
+
+   #postflag-bar .nav-button.close a:hover {
+      color: white;
+   }
    `;
 
    document.head.appendChild(flagStyles);


### PR DESCRIPTION
The close button in the flag bar is a troll:

![2018-03-03_21-59-05_chrome](https://user-images.githubusercontent.com/4585677/36939742-18fc4f96-1f2e-11e8-8a6c-f10cf3fef2ca.png)

Despite being a big rounded button, only the text *inside* the button is clickable. The decorative oval around it isn't.

Since we're already modifying that area, let's resolve that too. This change fixes the button's trollishness by:

* removing all the styling that defines the oval
* assigning all the same styling to the clickable `<a>`  element inside it.